### PR TITLE
QoS & Parallelism Level per label configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ TestResults.xml
 *.userprefs
 *.bak
 .paket/paket.exe
+StyleCop.Cache

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-﻿## 1.2.0
+﻿## 1.2.1
+ - QoS & PL default settings are now preserved if not specified in configufation.
+
+## 1.2.0
  - Incoming message listener QoS and parallelism level configuration added.
 
 ## 1.1.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-﻿## 1.1.1
+﻿## 1.2.0
+ - Incoming message listener QoS and parallelism level configuration added.
+
+## 1.1.1
  - Deleted destructor and overloaded Dispose method to leave only one option for endpoint deletion.
 
 ## 1.1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-﻿## 1.2.1
+﻿## 1.2.2
+ - QoS & PL settings can now be overriden if no endpoint configuration provided.
+
+## 1.2.1
  - QoS & PL default settings are now preserved if not specified in configufation.
 
 ## 1.2.0

--- a/Sources/Contour/Configurator/AppConfigConfigurator.cs
+++ b/Sources/Contour/Configurator/AppConfigConfigurator.cs
@@ -244,27 +244,41 @@ namespace Contour.Configurator
                 var configurator = cfg.On(incomingElement.Label).
                     WithAlias(incomingElement.Key);
 
-                var incomingQos = endpointConfig.Qos;
+                var qos = endpointConfig.Qos;
 
                 if (incomingElement.Qos != null && (incomingElement.Qos.PrefetchSize.HasValue || incomingElement.Qos.PrefetchCount.HasValue))
                 {
-                    incomingQos = incomingElement.Qos;
+                    qos = incomingElement.Qos;
                 }
 
                 ushort count = 0;
                 uint size = 0;
 
-                if (incomingQos.PrefetchCount.HasValue)
+                if (qos.PrefetchCount.HasValue)
                 {
-                    count = incomingQos.PrefetchCount.Value;
+                    count = qos.PrefetchCount.Value;
                 }
 
-                if (incomingQos.PrefetchSize.HasValue)
+                if (qos.PrefetchSize.HasValue)
                 {
-                    size = incomingQos.PrefetchSize.Value;
+                    size = qos.PrefetchSize.Value;
                 }
 
                 configurator.WithQoS(new QoSParams(count, size));
+
+                uint level = 0;
+
+                if (endpointConfig.ParallelismLevel.HasValue)
+                {
+                    level = endpointConfig.ParallelismLevel.Value;
+                }
+
+                if (incomingElement.ParallelismLevel.HasValue)
+                {
+                    level = incomingElement.ParallelismLevel.Value;
+                }
+
+                configurator.WithParallelismLevel(level);
 
                 if (incomingElement.RequiresAccept)
                 {

--- a/Sources/Contour/Configurator/AppConfigConfigurator.cs
+++ b/Sources/Contour/Configurator/AppConfigConfigurator.cs
@@ -244,42 +244,49 @@ namespace Contour.Configurator
                 var configurator = cfg.On(incomingElement.Label).
                     WithAlias(incomingElement.Key);
 
-                var qos = endpointConfig.Qos;
+                //this should be the default value
+                var qos = configurator.GetQoS();
 
-                if (incomingElement.Qos != null && (incomingElement.Qos.PrefetchSize.HasValue || incomingElement.Qos.PrefetchCount.HasValue))
+                if (qos.HasValue)
                 {
-                    qos = incomingElement.Qos;
+                    var size = qos.Value.PrefetchSize;
+                    var count = qos.Value.PrefetchCount;
+                    
+                    if (endpointConfig.Qos.PrefetchSize.HasValue)
+                    {
+                        size = endpointConfig.Qos.PrefetchSize.Value;
+
+                        if (incomingElement.Qos.PrefetchSize.HasValue)
+                        {
+                            size = incomingElement.Qos.PrefetchSize.Value;
+                        }
+                    }
+
+                    if (endpointConfig.Qos.PrefetchCount.HasValue)
+                    {
+                        count = endpointConfig.Qos.PrefetchCount.Value;
+
+                        if (incomingElement.Qos.PrefetchCount.HasValue)
+                        {
+                            count = incomingElement.Qos.PrefetchCount.Value;
+                        }
+                    }
+
+                    configurator.WithQoS(new QoSParams(count, size));
                 }
-
-                ushort count = 0;
-                uint size = 0;
-
-                if (qos.PrefetchCount.HasValue)
-                {
-                    count = qos.PrefetchCount.Value;
-                }
-
-                if (qos.PrefetchSize.HasValue)
-                {
-                    size = qos.PrefetchSize.Value;
-                }
-
-                configurator.WithQoS(new QoSParams(count, size));
-
-                uint level = 0;
 
                 if (endpointConfig.ParallelismLevel.HasValue)
                 {
-                    level = endpointConfig.ParallelismLevel.Value;
+                    var level = endpointConfig.ParallelismLevel.Value;
+
+                    if (incomingElement.ParallelismLevel.HasValue)
+                    {
+                        level = incomingElement.ParallelismLevel.Value;
+                    }
+
+                    configurator.WithParallelismLevel(level);
                 }
-
-                if (incomingElement.ParallelismLevel.HasValue)
-                {
-                    level = incomingElement.ParallelismLevel.Value;
-                }
-
-                configurator.WithParallelismLevel(level);
-
+                
                 if (incomingElement.RequiresAccept)
                 {
                     configurator.RequiresAccept();

--- a/Sources/Contour/Configurator/AppConfigConfigurator.cs
+++ b/Sources/Contour/Configurator/AppConfigConfigurator.cs
@@ -244,7 +244,6 @@ namespace Contour.Configurator
                 var configurator = cfg.On(incomingElement.Label).
                     WithAlias(incomingElement.Key);
 
-                //these values will never be used if UseRabbitMq() is not called on IBusConfigurator cfg
                 uint size = 0;
                 ushort count = 50;
 

--- a/Sources/Contour/Configurator/AppConfigConfigurator.cs
+++ b/Sources/Contour/Configurator/AppConfigConfigurator.cs
@@ -244,47 +244,48 @@ namespace Contour.Configurator
                 var configurator = cfg.On(incomingElement.Label).
                     WithAlias(incomingElement.Key);
 
-                //this should be the default value
-                var qos = configurator.GetQoS();
+                //these values will never be used if UseRabbitMq() is not called on IBusConfigurator cfg
+                uint size = 0;
+                ushort count = 50;
 
+                //this should be the default values provided by RabbitMQ configurator (BusConsumerConfigurationEx);
+                var qos = configurator.GetQoS();
                 if (qos.HasValue)
                 {
-                    var size = qos.Value.PrefetchSize;
-                    var count = qos.Value.PrefetchCount;
-                    
-                    if (endpointConfig.Qos.PrefetchSize.HasValue)
-                    {
-                        size = endpointConfig.Qos.PrefetchSize.Value;
-
-                        if (incomingElement.Qos.PrefetchSize.HasValue)
-                        {
-                            size = incomingElement.Qos.PrefetchSize.Value;
-                        }
-                    }
-
-                    if (endpointConfig.Qos.PrefetchCount.HasValue)
-                    {
-                        count = endpointConfig.Qos.PrefetchCount.Value;
-
-                        if (incomingElement.Qos.PrefetchCount.HasValue)
-                        {
-                            count = incomingElement.Qos.PrefetchCount.Value;
-                        }
-                    }
-
-                    configurator.WithQoS(new QoSParams(count, size));
+                    size = qos.Value.PrefetchSize;
+                    count = qos.Value.PrefetchCount;
                 }
+
+                if (endpointConfig.Qos.PrefetchSize.HasValue)
+                {
+                    size = endpointConfig.Qos.PrefetchSize.Value;
+                }
+
+                if (incomingElement.Qos.PrefetchSize.HasValue)
+                {
+                    size = incomingElement.Qos.PrefetchSize.Value;
+                }
+
+                if (endpointConfig.Qos.PrefetchCount.HasValue)
+                {
+                    count = endpointConfig.Qos.PrefetchCount.Value;
+                }
+
+                if (incomingElement.Qos.PrefetchCount.HasValue)
+                {
+                    count = incomingElement.Qos.PrefetchCount.Value;
+                }
+
+                configurator.WithQoS(new QoSParams(count, size));
 
                 if (endpointConfig.ParallelismLevel.HasValue)
                 {
-                    var level = endpointConfig.ParallelismLevel.Value;
+                    configurator.WithParallelismLevel(endpointConfig.ParallelismLevel.Value);
+                }
 
-                    if (incomingElement.ParallelismLevel.HasValue)
-                    {
-                        level = incomingElement.ParallelismLevel.Value;
-                    }
-
-                    configurator.WithParallelismLevel(level);
+                if (incomingElement.ParallelismLevel.HasValue)
+                {
+                    configurator.WithParallelismLevel(incomingElement.ParallelismLevel.Value);
                 }
                 
                 if (incomingElement.RequiresAccept)

--- a/Sources/Contour/Configurator/IncomingElement.cs
+++ b/Sources/Contour/Configurator/IncomingElement.cs
@@ -81,6 +81,15 @@
             }
         }
 
+        [ConfigurationProperty("parallelismLevel", IsRequired = false)]
+        public uint? ParallelismLevel
+        {
+            get
+            {
+                return (uint?) base["parallelismLevel"];
+            }
+        }
+
         #endregion
     }
 }

--- a/Sources/Contour/Configurator/IncomingElement.cs
+++ b/Sources/Contour/Configurator/IncomingElement.cs
@@ -69,6 +69,18 @@
             }
         }
 
+        /// <summary>
+        /// Gets QoS for incoming messages listener
+        /// </summary>
+        [ConfigurationProperty("qos")]
+        public QosElement Qos
+        {
+            get
+            {
+                return (QosElement)base["qos"];
+            }
+        }
+
         #endregion
     }
 }

--- a/Sources/Contour/Configurator/QosElement.cs
+++ b/Sources/Contour/Configurator/QosElement.cs
@@ -18,5 +18,17 @@ namespace Contour.Configurator
                 return (ushort?)base["prefetchCount"];
             }
         }
+
+        /// <summary>
+        /// Количество сообщений, которые должен обработать получатель, прежде чем получит новую порцию данных.
+        /// </summary>
+        [ConfigurationProperty("prefetchSize", IsRequired = true)]
+        public uint? PrefetchSize
+        {
+            get
+            {
+                return (uint?)base["prefetchSize"];
+            }
+        }
     }
 }

--- a/Sources/Contour/Configurator/QosElement.cs
+++ b/Sources/Contour/Configurator/QosElement.cs
@@ -22,7 +22,7 @@ namespace Contour.Configurator
         /// <summary>
         /// Количество сообщений, которые должен обработать получатель, прежде чем получит новую порцию данных.
         /// </summary>
-        [ConfigurationProperty("prefetchSize", IsRequired = true)]
+        [ConfigurationProperty("prefetchSize", IsRequired = false)]
         public uint? PrefetchSize
         {
             get

--- a/Sources/Contour/Receiving/IReceiverConfigurator.cs
+++ b/Sources/Contour/Receiving/IReceiverConfigurator.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using Contour.Helpers;
 using Contour.Receiving.Consumers;
 using Contour.Validation;
 

--- a/Sources/Contour/Receiving/IReceiverConfigurator.cs
+++ b/Sources/Contour/Receiving/IReceiverConfigurator.cs
@@ -88,7 +88,7 @@ namespace Contour.Receiving
         /// <param name="parallelismLevel">Количество одновременных обработчиков входящих сообщений.</param>
         /// <returns>Конфигуратор получателя с установленным количеством одновременных обработчиков входящих сообщений.</returns>
         IReceiverConfigurator WithParallelismLevel(uint parallelismLevel);
-
+        
         /// <summary>
         /// Устанавливает хранилище заголовков входящего сообщения.
         /// </summary>

--- a/Sources/Contour/Transport/RabbitMQ/BusConfigurationEx.cs
+++ b/Sources/Contour/Transport/RabbitMQ/BusConfigurationEx.cs
@@ -26,7 +26,7 @@ namespace Contour.Transport.RabbitMQ
         /// <param name="prefetchCount">Количество сообщений получаемых из шины за одно обращение, т.е. размер порции данных.</param>
         /// <param name="prefetchSize">Количество сообщений, которые должен обработать получатель, прежде чем получит новую порцию данных.</param>
         /// <returns>Конфигурация экземпляра шины сообщений.</returns>
-        public static IBusConfigurator SetDefaultQoS(this IBusConfigurator busConfigurator, ushort prefetchCount, uint prefetchSize = 0)
+        public static IBusConfigurator SetDefaultQoS(this IBusConfigurator busConfigurator, ushort prefetchCount, uint prefetchSize = 0) 
         {
             // TODO: beautify
             ((RabbitReceiverOptions)((BusConfiguration)busConfigurator).ReceiverDefaults).QoS = new QoSParams(prefetchCount, prefetchSize);

--- a/Sources/Contour/Transport/RabbitMQ/BusConsumerConfigurationEx.cs
+++ b/Sources/Contour/Transport/RabbitMQ/BusConsumerConfigurationEx.cs
@@ -7,6 +7,8 @@
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
+using Contour.Helpers;
+
 namespace Contour.Transport.RabbitMQ
 {
     using Contour.Receiving;
@@ -35,6 +37,17 @@ namespace Contour.Transport.RabbitMQ
             ((RabbitReceiverOptions)((ReceiverConfiguration)builder).Options).QoS = qosParams;
 
             return builder;
+        }
+
+        /// <summary>
+        /// Returns current QoS settings
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static Maybe<QoSParams> GetQoS(this IReceiverConfigurator builder)
+        {
+            var qos = ((RabbitReceiverOptions)((ReceiverConfiguration)builder).Options).GetQoS();
+            return qos;
         }
 
         /// <summary>

--- a/Sources/Contour/Transport/RabbitMQ/BusConsumerConfigurationEx.cs
+++ b/Sources/Contour/Transport/RabbitMQ/BusConsumerConfigurationEx.cs
@@ -46,8 +46,9 @@ namespace Contour.Transport.RabbitMQ
         /// <returns></returns>
         public static Maybe<QoSParams> GetQoS(this IReceiverConfigurator builder)
         {
-            var qos = ((RabbitReceiverOptions)((ReceiverConfiguration)builder).Options).GetQoS();
-            return qos;
+            var config = builder as ReceiverConfiguration;
+            var options = config?.Options as RabbitReceiverOptions;
+            return options != null ? options.GetQoS() : Maybe<QoSParams>.Empty;
         }
 
         /// <summary>

--- a/Sources/Contour/Transport/RabbitMQ/QoSParams.cs
+++ b/Sources/Contour/Transport/RabbitMQ/QoSParams.cs
@@ -18,7 +18,6 @@ namespace Contour.Transport.RabbitMQ
 
         /// <summary>
         /// Инициализирует новый экземпляр класса <see cref="QoSParams"/>. 
-        /// The qo s params.
         /// </summary>
         /// <param name="prefetchCount">
         /// Количество сообщений получаемых из шины за одно обращение, т.е. размер порции данных.

--- a/Tests/Contour.Configurator.Tests/ConfigSectionReadingSpecs.cs
+++ b/Tests/Contour.Configurator.Tests/ConfigSectionReadingSpecs.cs
@@ -477,8 +477,8 @@
             public void should_read_configuration_property()
             {
                 const string endpointName = "ep";
-                const int prefetchCount = 5;
-                const int prefetchSize = 6;
+                const ushort prefetchCount = 5;
+                const uint prefetchSize = 6;
                 const string onKeyName = "key";
 
                 string Config =
@@ -498,8 +498,62 @@
 
                 var on = elements.First(e => e.Key == onKeyName);
 
-                on.Qos.PrefetchCount.Should().Be(prefetchCount);
-                on.Qos.PrefetchSize.Should().Be(prefetchSize);
+                on.Qos.PrefetchCount.Should().Be(prefetchCount, "Incoming QoS prefetch count should be set");
+                on.Qos.PrefetchSize.Should().Be(prefetchSize, "Incoming QoS prefetch size should be set");
+            }
+        }
+
+        [TestFixture]
+        [Category("Unit")]
+        public class when_declaring_parallelism_level_for_incoming
+        {
+            [Test]
+            public void should_read_configuration_property()
+            {
+                const string endpointName = "ep";
+                const string onKeyName = "key";
+                const uint parallelismLevel = 7;
+
+                string Config =
+                    $@"<endpoints>
+                        <endpoint name=""{endpointName}"" connectionString=""amqp://localhost:666"">
+                                <incoming>
+                                    <on key=""{onKeyName}"" label=""msg.a"" react=""DynamicHandler"" requiresAccept=""true"" parallelismLevel=""{parallelismLevel}"">
+                                    </on>
+                                </incoming>
+                        </endpoint>
+                    </endpoints>";
+
+                var section = new XmlEndpointsSection(Config);
+                var endpoint = section.Endpoints[endpointName];
+                var elements = endpoint.Incoming.OfType<IncomingElement>();
+
+                var on = elements.First(e => e.Key == onKeyName);
+                on.ParallelismLevel.Should().Be(parallelismLevel, "Incoming parallelism level should be set");
+            }
+
+            [Test]
+            public void should_use_default_value_if_not_set()
+            {
+                const string endpointName = "ep";
+                const string onKeyName = "key";
+
+                string Config =
+                    $@"<endpoints>
+                        <endpoint name=""{endpointName}"" connectionString=""amqp://localhost:666"">
+                                <incoming>
+                                    <on key=""{onKeyName}"" label=""msg.a"" react=""DynamicHandler"" requiresAccept=""true"" >
+                                    </on>
+                                </incoming>
+                        </endpoint>
+                    </endpoints>";
+
+                var section = new XmlEndpointsSection(Config);
+                var endpoint = section.Endpoints[endpointName];
+                var elements = endpoint.Incoming.OfType<IncomingElement>();
+
+                var on = elements.First(e => e.Key == onKeyName);
+                on.ParallelismLevel.Should().BeNull("Incoming parallelism level should not be set");
             }
         }
     }


### PR DESCRIPTION
This update enables QoS and parallelism level configuration for a specific incoming message flow. If these settings are not specified the endpoint configuration is used.