### PR TITLE
Callback receiver introduced

### DIFF
--- a/Sources/Contour/Contour.csproj
+++ b/Sources/Contour/Contour.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Transport\RabbitMQ\Internal\ListenerStoppedEventArgs.cs" />
     <Compile Include="Transport\RabbitMQ\Internal\OperationStopReason.cs" />
     <Compile Include="Transport\RabbitMQ\Internal\ProducerStoppedEventArgs.cs" />
+    <Compile Include="Transport\RabbitMQ\Internal\RabbitCallbackReceiver.cs" />
     <Compile Include="Transport\RabbitMQ\UnconfirmedMessageException.cs" />
     <Compile Include="Transport\RabbitMQ\Internal\RoundRobinSelector.cs" />
     <Compile Include="Transport\RabbitMQ\Internal\FaultTolerantProducer.cs" />

--- a/Sources/Contour/Receiving/ReceiverConfiguration.cs
+++ b/Sources/Contour/Receiving/ReceiverConfiguration.cs
@@ -19,7 +19,6 @@ namespace Contour.Receiving
         public ReceiverConfiguration(MessageLabel label, ReceiverOptions parentOptions)
         {
             this.Label = label;
-
             this.Options = (ReceiverOptions)parentOptions.Derive();
         }
 

--- a/Sources/Contour/Transport/RabbitMQ/Internal/IListener.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/IListener.cs
@@ -17,7 +17,7 @@ namespace Contour.Transport.RabbitMQ.Internal
         IEnumerable<MessageLabel> AcceptedLabels { get; }
 
         string BrokerUrl { get; }
-
+        
         ISubscriptionEndpoint Endpoint { get; }
 
         RabbitReceiverOptions ReceiverOptions { get; }

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitCallbackReceiver.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitCallbackReceiver.cs
@@ -1,0 +1,17 @@
+using Contour.Receiving;
+
+namespace Contour.Transport.RabbitMQ.Internal
+{
+    internal class RabbitCallbackReceiver : RabbitReceiver
+    {
+        public RabbitCallbackReceiver(RabbitBus bus, IReceiverConfiguration configuration, IConnectionPool<IRabbitConnection> connectionPool)
+            : base(bus, configuration, connectionPool)
+        {
+        }
+
+        protected override void OnListenerRegistered(IListener listener)
+        {
+            // Suppress listener registrations for the callback receiver
+        }
+    }
+}

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitSender.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitSender.cs
@@ -220,7 +220,7 @@ namespace Contour.Transport.RabbitMQ.Internal
                 if (this.Configuration.RequiresCallback)
                 {
                     var callbackConfiguration = this.CreateCallbackReceiverConfiguration(url);
-                    var receiver = this.bus.RegisterReceiver(callbackConfiguration);
+                    var receiver = this.bus.RegisterReceiver(callbackConfiguration, true);
 
                     this.logger.Trace(
                         $"A sender of [{this.Configuration.Label}] requires a callback configuration; registering a receiver of [{callbackConfiguration.Label}] with connection string [{callbackConfiguration.Options.GetConnectionString()}]");
@@ -293,7 +293,7 @@ namespace Contour.Transport.RabbitMQ.Internal
         private ReceiverConfiguration CreateCallbackReceiverConfiguration(string url)
         {
             var callbackConfiguration = new ReceiverConfiguration(
-                this.Configuration.Label,
+                MessageLabel.Any,
                 this.Configuration.CallbackConfiguration.Options);
 
             callbackConfiguration.WithConnectionString(url);


### PR DESCRIPTION
A separate callback receiver is created to handle responses in request-response scenarios. This type of receiver will not notify others about its' listeners registration which will protect it from attaching any consuming actions (subscription handling logic).