### PR TITLE
Connection string provider code configuration

### DIFF
--- a/Sources/Contour/Configuration/BusConfiguration.cs
+++ b/Sources/Contour/Configuration/BusConfiguration.cs
@@ -282,7 +282,12 @@ namespace Contour.Configuration
             }
 
             var provider = this.ReceiverDefaults.GetConnectionStringProvider();
-            this.ReceiverDefaults.ConnectionString = provider?.GetConnectionString(label) ?? this.ReceiverDefaults.GetConnectionString();
+            var connectionString = provider?.GetConnectionString(label);
+
+            if (!string.IsNullOrEmpty(connectionString))
+            {
+                this.ReceiverDefaults.ConnectionString = connectionString;
+            }
 
             var configuration = new ReceiverConfiguration(label, this.ReceiverDefaults);
             this.receiverConfigurations.Add(configuration);
@@ -401,7 +406,12 @@ namespace Contour.Configuration
             }
 
             var provider = this.SenderDefaults.GetConnectionStringProvider();
-            this.SenderDefaults.ConnectionString = provider?.GetConnectionString(label) ?? this.SenderDefaults.GetConnectionString();
+            var connectionString = provider?.GetConnectionString(label);
+
+            if (!string.IsNullOrEmpty(connectionString))
+            {
+                this.SenderDefaults.ConnectionString = connectionString;
+            }
 
             var configuration = new SenderConfiguration(label, this.SenderDefaults, this.ReceiverDefaults);
             this.senderConfigurations.Add(configuration);

--- a/Sources/Contour/Configuration/BusConfiguration.cs
+++ b/Sources/Contour/Configuration/BusConfiguration.cs
@@ -611,13 +611,7 @@ namespace Contour.Configuration
             {
                 throw new BusConfigurationException("Bus factory is not set.");
             }
-
-            if (string.IsNullOrEmpty(this.ConnectionString))
-            {
-                throw new BusConfigurationException(@"Не задана строка подключения к шине. Строку подключения можно задать явно при создании IBus 
-												или в конфигурационном файле приложения в секции /configuration/connectionStrings/add[@address='service-bus']");
-            }
-
+            
             if (this.Endpoint == null)
             {
                 throw new BusConfigurationException("Не задано название компонента (Endpoint).");

--- a/Sources/Contour/Configuration/EndpointOptions.cs
+++ b/Sources/Contour/Configuration/EndpointOptions.cs
@@ -1,4 +1,4 @@
-﻿using Contour.Sending;
+﻿using Contour.Configurator;
 
 namespace Contour.Configuration
 {
@@ -37,6 +37,11 @@ namespace Contour.Configuration
         public Maybe<string> ConnectionString { protected get; set; }
 
         /// <summary>
+        /// Gets or sets the connection string provider.
+        /// </summary>
+        public IConnectionStringProvider ConnectionStringProvider { protected get; set; }
+
+        /// <summary>
         /// Gets or sets the number of attempts to take when failing over
         /// </summary>
         public int? FailoverAttempts { protected get; set; }
@@ -55,6 +60,15 @@ namespace Contour.Configuration
         public Maybe<string> GetConnectionString()
         {
             return this.Pick<EndpointOptions, string>(o => o.ConnectionString);
+        }
+
+        /// <summary>
+        /// Returns the endpoint connection string provider.
+        /// </summary>
+        /// <returns></returns>
+        public IConnectionStringProvider GetConnectionStringProvider()
+        {
+            return this.Pick<EndpointOptions, IConnectionStringProvider>(o => o.ConnectionStringProvider);
         }
 
         /// <summary>

--- a/Sources/Contour/Configuration/IBusConfigurator.cs
+++ b/Sources/Contour/Configuration/IBusConfigurator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Contour.Configurator;
 
 namespace Contour.Configuration
 {
@@ -309,5 +310,11 @@ namespace Contour.Configuration
         /// </summary>
         /// <param name="storage"></param>
         void UseIncomingMessageHeaderStorage(IIncomingMessageHeaderStorage storage);
+
+        /// <summary>
+        /// Sets the bus connection string provider
+        /// </summary>
+        /// <param name="provider"></param>
+        void UseConnectionStringProvider(IConnectionStringProvider provider);
     }
 }

--- a/Sources/Contour/Configurator/EndpointElement.cs
+++ b/Sources/Contour/Configurator/EndpointElement.cs
@@ -50,7 +50,7 @@ namespace Contour.Configurator
         /// <summary>
         /// Gets or sets the connection string.
         /// </summary>
-        [ConfigurationProperty("connectionString", IsRequired = true)]
+        [ConfigurationProperty("connectionString", IsRequired = false)]
         public string ConnectionString
         {
             get

--- a/Sources/Contour/Contour.csproj
+++ b/Sources/Contour/Contour.csproj
@@ -265,7 +265,7 @@
     <Compile Include="BusFactory.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="IEndpoint.cs" />
-    <Compile Include="Transport\RabbitMQ\BusConsumerConfigurationEx.cs" />
+    <Compile Include="Transport\RabbitMQ\BusReceiverConfigurationEx.cs" />
     <Compile Include="IBus.cs" />
     <Compile Include="IMessageLabelHandler.cs" />
     <Compile Include="Receiving\Consumers\LambdaConsumerOf.cs" />

--- a/Sources/Contour/Transport/RabbitMQ/BusSenderConfigurationEx.cs
+++ b/Sources/Contour/Transport/RabbitMQ/BusSenderConfigurationEx.cs
@@ -24,6 +24,13 @@ namespace Contour.Transport.RabbitMQ
             var senderConfiguration = (SenderConfiguration)builder;
             var rabbitSenderOptions = (RabbitSenderOptions)senderConfiguration.Options;
 
+            // The connection string should not be overridden if the connection string provider is present and it does not return nulls
+            var provider = rabbitSenderOptions.GetConnectionStringProvider();
+            if (!string.IsNullOrEmpty(provider?.GetConnectionString(senderConfiguration.Label)))
+            {
+                return builder;
+            }
+
             // Need to set the callback sender's connection string to use the same connection string both in sender and receiver in request-response scenario
             senderConfiguration.WithCallbackConnectionString(connectionString);
             rabbitSenderOptions.ConnectionString = connectionString;

--- a/Tests/Contour.Configurator.Tests/BusConfigurationSpecs.cs
+++ b/Tests/Contour.Configurator.Tests/BusConfigurationSpecs.cs
@@ -1228,7 +1228,7 @@ namespace Contour.Configurator.Tests
                 const string name = "name";
                 const string provider = "provider";
                 string Config = $@"<endpoints>
-                                       <endpoint name=""{name}"" connectionString="""" connectionStringProvider=""{provider}"" />
+                                       <endpoint name=""{name}"" connectionStringProvider=""{provider}"" />
                                    </endpoints>";
 
                 var resolverMock = new Mock<IDependencyResolver>();
@@ -1251,7 +1251,7 @@ namespace Contour.Configurator.Tests
             {
                 const string name = "name";
                 string Config = $@"<endpoints>
-                                       <endpoint name=""{name}"" connectionString="""" />
+                                       <endpoint name=""{name}"" />
                                    </endpoints>";
 
                 var resolverMock = new Mock<IDependencyResolver>();
@@ -1304,7 +1304,6 @@ namespace Contour.Configurator.Tests
                     $@"<endpoints>
                         <endpoint 
                             name=""{Name}"" 
-                            connectionString=""{SomeString}"" 
                             connectionStringProvider=""{Provider}"" >
                             <outgoing>
                                 <route key=""a"" label=""{Label}"" />
@@ -1344,7 +1343,6 @@ namespace Contour.Configurator.Tests
             public void should_override_connection_string_to_outgoing_label_from_provider_if_present()
             {
                 const string Name = "name";
-                const string SomeString = "some string";
                 const string AnotherString = "another string";
                 const string Provider = "provider";
                 const string Label = "msg.a";
@@ -1352,7 +1350,6 @@ namespace Contour.Configurator.Tests
                     $@"<endpoints>
                         <endpoint 
                             name=""{Name}"" 
-                            connectionString=""{SomeString}"" 
                             connectionStringProvider=""{Provider}"" >
                             <outgoing>
                                 <route key=""a"" label=""{Label}"" connectionString=""outgoing connection string"" />
@@ -1381,7 +1378,6 @@ namespace Contour.Configurator.Tests
                 busConfiguration.UseRabbitMq();
 
                 var configuration = (BusConfiguration)configurator.Configure(Name, busConfiguration);
-
                 var senderConfiguration = configuration.SenderConfigurations.First(sc => sc.Label.Equals(MessageLabel.From(Label)));
 
                 var senderOptions = (RabbitSenderOptions)senderConfiguration.Options;
@@ -1392,7 +1388,6 @@ namespace Contour.Configurator.Tests
             public void should_use_connection_string_from_outgoing_label_if_provider_returns_null()
             {
                 const string Name = "name";
-                const string EndpointString = "endpoint string";
                 const string LabelString = "outgoing connection string";
                 const string Provider = "provider";
                 const string Label = "msg.a";
@@ -1400,7 +1395,6 @@ namespace Contour.Configurator.Tests
                     $@"<endpoints>
                         <endpoint 
                             name=""{Name}"" 
-                            connectionString=""{EndpointString}"" 
                             connectionStringProvider=""{Provider}"" >
                             <outgoing>
                                 <route key=""a"" label=""{Label}"" connectionString=""{LabelString}"" />
@@ -1449,7 +1443,6 @@ namespace Contour.Configurator.Tests
                     $@"<endpoints>
                         <endpoint 
                             name=""{Name}"" 
-                            connectionString=""{SomeString}"" 
                             connectionStringProvider=""{Provider}"" >
                             <incoming>
                                 <on key=""a"" label=""{Label}"" react=""BooHandler"" type=""BooMessage"" lifestyle=""Delegated"" />
@@ -1489,7 +1482,6 @@ namespace Contour.Configurator.Tests
             public void should_override_connection_string_on_incoming_label_from_provider_if_present()
             {
                 const string Name = "name";
-                const string SomeString = "some string";
                 const string AnotherString = "another string";
                 const string Provider = "provider";
                 const string Label = "msg.a";
@@ -1497,7 +1489,6 @@ namespace Contour.Configurator.Tests
                     $@"<endpoints>
                         <endpoint 
                             name=""{Name}"" 
-                            connectionString=""{SomeString}"" 
                             connectionStringProvider=""{Provider}"" >
                             <incoming>
                                 <on key=""a"" label=""{Label}"" connectionString=""incoming connection string"" react=""BooHandler"" type=""BooMessage"" lifestyle=""Delegated"" />
@@ -1537,7 +1528,6 @@ namespace Contour.Configurator.Tests
             public void should_use_connection_string_from_incoming_label_if_provider_returns_null()
             {
                 const string Name = "name";
-                const string EndpointString = "endpoint string";
                 const string LabelString = "incoming connection string";
                 const string Provider = "provider";
                 const string Label = "msg.a";
@@ -1545,7 +1535,6 @@ namespace Contour.Configurator.Tests
                     $@"<endpoints>
                         <endpoint 
                             name=""{Name}"" 
-                            connectionString=""{EndpointString}"" 
                             connectionStringProvider=""{Provider}"" >
                             <incoming>
                                 <on key=""a"" label=""{Label}"" connectionString=""{LabelString}"" react=""BooHandler"" type=""BooMessage"" lifestyle=""Delegated"" />
@@ -1580,7 +1569,6 @@ namespace Contour.Configurator.Tests
                 var receiverOptions = (RabbitReceiverOptions)receiverConfiguration.Options;
                 receiverOptions.GetConnectionString().Value.Should().Be(LabelString, "Should use a connection string from the outgoing label.");
             }
-
         }
 
 

--- a/Tests/Contour.Configurator.Tests/BusConfigurationSpecs.cs
+++ b/Tests/Contour.Configurator.Tests/BusConfigurationSpecs.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using Contour.Configuration;
 using Contour.Helpers;
+using Contour.Serialization;
 using Contour.Testing.Transport.RabbitMq;
 using Contour.Transport.RabbitMQ;
 
@@ -1198,6 +1199,29 @@ namespace Contour.Configurator.Tests
         [Category("Unit")]
         public class when_configuring_endpoint_with_connection_string
         {
+            [Test]
+            public void should_not_throw_on_validate_if_not_present()
+            {
+                const string name = "name";
+                string Config = $@"<endpoints>
+                                       <endpoint name=""{name}"" />
+                                   </endpoints>";
+
+                var resolverMock = new Mock<IDependencyResolver>();
+                var busConfigurator = new BusConfiguration();
+
+                var section = new XmlEndpointsSection(Config);
+                var configurator = new AppConfigConfigurator(section, resolverMock.Object);
+                var configuration = (BusConfiguration)configurator.Configure(name, busConfigurator);
+
+                busConfigurator.BuildBusUsing(bc => new Mock<IBus>().Object);
+                busConfigurator.UsePayloadConverter(new Mock<IPayloadConverter>().Object);
+                busConfigurator.Route("label");
+
+                Action validate = () => configuration.Validate();
+                validate.ShouldNotThrow("Connection string may not be specified");
+            }
+
             [Test]
             public void should_set_connection_string_if_present()
             {

--- a/Tests/Contour.Configurator.Tests/ConfigSectionReadingSpecs.cs
+++ b/Tests/Contour.Configurator.Tests/ConfigSectionReadingSpecs.cs
@@ -493,14 +493,14 @@
             }
 
             [Test]
-            public void should_throw_if_not_set()
+            public void should_not_throw_if_not_set()
             {
                 const string config = @"<endpoints>
                                             <endpoint name=""Tester"" />
                                         </endpoints>";
 
                 Action readingConfig = () => new XmlEndpointsSection(config);
-                readingConfig.ShouldThrow<ConfigurationErrorsException>();
+                readingConfig.ShouldNotThrow<ConfigurationErrorsException>();
             }
         }
 

--- a/Tests/Contour.RabbitMq.Tests/BusConfigurationSpecs.cs
+++ b/Tests/Contour.RabbitMq.Tests/BusConfigurationSpecs.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 
 using Contour.Configuration;
 using Contour.Configurator;
+using Contour.Serialization;
 using Contour.Testing.Transport.RabbitMq;
 using Contour.Transport.RabbitMQ;
 using Contour.Transport.RabbitMQ.Topology;
@@ -235,6 +236,25 @@ namespace Contour.RabbitMq.Tests
                 var receiverStorage = configuration.ReceiverDefaults.GetIncomingMessageHeaderStorage();
                 receiverStorage.HasValue.Should().BeTrue();
                 receiverStorage.Value.Should().Be(storage);
+            }
+        }
+
+        [TestFixture]
+        [Category("Unit")]
+        public class when_configuring_endpoint_with_connection_string
+        {
+            [Test]
+            public void should_not_throw_on_validate_if_not_present()
+            {
+                var configuration = new BusConfiguration();
+
+                configuration.SetEndpoint("endpoint");
+                configuration.BuildBusUsing(bc => new Mock<IBus>().Object);
+                configuration.UsePayloadConverter(new Mock<IPayloadConverter>().Object);
+                configuration.Route("label");
+
+                Action validate = () => configuration.Validate();
+                validate.ShouldNotThrow("Connection string may not be specified");
             }
         }
 

--- a/Tests/Contour.RabbitMq.Tests/ConnectionSpecs.cs
+++ b/Tests/Contour.RabbitMq.Tests/ConnectionSpecs.cs
@@ -182,8 +182,6 @@ namespace Contour.RabbitMq.Tests
                     cfg =>
                         {
                             cfg.SetConnectionString("amqp://10.10.10.10/integration");
-                            cfg.UseRabbitMq();
-
                             cfg.Route("some.label"); // just to pass validation
                         });
 

--- a/Tests/Contour.RabbitMq.Tests/ConnectionSpecs.cs
+++ b/Tests/Contour.RabbitMq.Tests/ConnectionSpecs.cs
@@ -182,6 +182,7 @@ namespace Contour.RabbitMq.Tests
                     cfg =>
                         {
                             cfg.SetConnectionString("amqp://10.10.10.10/integration");
+                            cfg.UseRabbitMq();
 
                             cfg.Route("some.label"); // just to pass validation
                         });


### PR DESCRIPTION
The connection string provider can now be configured in code. The endpoint connection string is now optional.