### PR TITLE
Fix cached value check

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,8 @@
-﻿## 1.8.1
+﻿## 1.8.2
+- Fixed
+    + Cached value check bug
+
+## 1.8.1
 - Changes:
     + narrowed metric tags list
 

--- a/Sources/Contour/Caching/CachingConsumerOf.cs
+++ b/Sources/Contour/Caching/CachingConsumerOf.cs
@@ -39,13 +39,14 @@ namespace Contour.Caching
                 return;
             }
 
-            var cached = this.cacheConfiguration.Cache.ContainsKey(message);
+            var cachedValue = this.cacheConfiguration.Cache[message];
+            var cached = cachedValue != null;
 
             this.CollectMetrics(message.Label.ToString(), cached);
 
             if (cached)
             {
-                context.Reply(this.cacheConfiguration.Cache[message]);
+                context.Reply(cachedValue);
                 return;
             }
 

--- a/Sources/Contour/Caching/CachingFilterDecorator.cs
+++ b/Sources/Contour/Caching/CachingFilterDecorator.cs
@@ -45,13 +45,14 @@ namespace Contour.Caching
                 return filter.Process(exchange, invoker);
             }
 
-            var cached = config.Cache.ContainsKey(exchange.Out);
+            var cachedValue = config.Cache[exchange.Out];
+            var cached = cachedValue != null;
 
             this.CollectMetrics(messageLabel, cached);
 
             if (cached)
             {
-                exchange.In = new Message(MessageLabel.Empty, config.Cache[exchange.Out]);
+                exchange.In = new Message(MessageLabel.Empty, cachedValue);
                 return Filter.Result(exchange);
             }
 

--- a/Sources/Contour/Caching/ICache.cs
+++ b/Sources/Contour/Caching/ICache.cs
@@ -6,6 +6,7 @@
     {
         object this[IMessage key] { get; }
 
+        [Obsolete("Use this[key] with null check")]
         bool ContainsKey(IMessage key);
 
         void Set(IMessage key, object value, TimeSpan ttl);

--- a/Tests/Contour.Common.Tests/TestImplementations/DictionaryCache.cs
+++ b/Tests/Contour.Common.Tests/TestImplementations/DictionaryCache.cs
@@ -17,7 +17,19 @@ namespace Contour.Common.Tests.TestImplementations
             return this.innerCache.ContainsKey(this.hasher.GetHash(key));
         }
 
-        public object this[IMessage key] => this.innerCache[this.hasher.GetHash(key)];
+        public object this[IMessage key]
+        {
+            get
+            {
+                var hash = this.hasher.GetHash(key);
+                if (this.innerCache.ContainsKey(hash))
+                {
+                    return this.innerCache[hash];
+                }
+
+                return null;
+            }
+        }
 
         public void Set(IMessage key, object value, TimeSpan ttl)
         {

--- a/Tests/Contour.Configurator.Tests/BusConfigurationSpecs.cs
+++ b/Tests/Contour.Configurator.Tests/BusConfigurationSpecs.cs
@@ -335,7 +335,19 @@ namespace Contour.Configurator.Tests
                 return this.innerCache.ContainsKey(this.hasher.GetHash(key));
             }
 
-            public object this[IMessage key] => this.innerCache[this.hasher.GetHash(key)];
+            public object this[IMessage key]
+            {
+                get
+                {
+                    var hash = this.hasher.GetHash(key);
+                    if (this.innerCache.ContainsKey(hash))
+                    {
+                        return this.innerCache[hash];
+                    }
+
+                    return null;
+                }
+            }
 
             public void Set(IMessage key, object value, TimeSpan ttl)
             {


### PR DESCRIPTION
Getting cached value is splitted into checking value existence in cache and, if value exists, getting it. Sometimes cached value is expired between check and getting, so these operations in this PR are merged into one with comparing result to null.