### PR TITLE
Fix BusNotReady exception on start

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,7 @@
-﻿## 2.2.0-core1
+﻿## 2.2.1-core1
+ fix BusNotReady on start
+
+## 2.2.0-core1
 	Upgraded RabbitMQ.Client to 6.1.0 for optimization CPU
 
 ## 2.1.0-core9

--- a/Sources/Contour/Contour.csproj
+++ b/Sources/Contour/Contour.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>contour servicebus bus</PackageTags>
-    <PackageReleaseNotes>Changed build scheme</PackageReleaseNotes>
-    <Copyright>Social Discovery Ventures © 2019</Copyright>
+    <PackageReleaseNotes>Fix BusNotReady on start</PackageReleaseNotes>
+    <Copyright>Social Discovery Ventures © 2020</Copyright>
     <Description>The package contains abstract interfaces of service bus and specific transport implementation for AMQP/RabbitMQ</Description>
     <Company>Social Discovery Ventures</Company>
     <Authors>SDV Team</Authors>
-    <Version>2.1.0-core9</Version>
+    <Version>2.2.1-core1</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   

--- a/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
@@ -432,8 +432,20 @@ namespace Contour.Transport.RabbitMQ.Internal
             {
                 var consumer = this.InitializeConsumer(token, out var channel);
 
+                var waitSecond = 0;
                 // если шина так и не стала готова работать, то не смысла начинать слушать сообщения, что бы потом их потерять
-                this.busContext.WhenReady.WaitOne();
+                while (true)
+                {
+                    if (!this.busContext.WhenReady.WaitOne(60000))
+                    {
+                        waitSecond += 60;
+                        this.logger.Warn(m => m ("Wait when bus [{0}] will be ready already {1} seconds. Continue waiting.", this.busContext.Endpoint.Address, waitSecond));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
 
                 this.logger.Info($"Listner {this} start consuming.");
 

--- a/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
@@ -269,7 +269,7 @@ namespace Contour.Transport.RabbitMQ.Internal
                                 TaskScheduler.Default)));
 
                 this.isConsuming = true;
-                this.logger.Trace("Listener started successfully");
+                this.logger.Trace("Listener's workers started successfully");
             }
         }
 
@@ -434,6 +434,8 @@ namespace Contour.Transport.RabbitMQ.Internal
 
                 // если шина так и не стала готова работать, то не смысла начинать слушать сообщения, что бы потом их потерять
                 this.busContext.WhenReady.WaitOne();
+
+                this.logger.Info($"Listner {this} start consuming.");
 
                 while (!token.IsCancellationRequested)
                 {

--- a/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
@@ -77,6 +77,7 @@ namespace Contour.Transport.RabbitMQ.Internal
         private ITicketTimer ticketTimer;
         private ConcurrentBag<Task> workers;
 
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Listener"/> class. 
         /// </summary>
@@ -188,8 +189,7 @@ namespace Contour.Transport.RabbitMQ.Internal
         /// </returns>
         public Task<IMessage> Expect(string correlationId, Type expectedResponseType, TimeSpan? timeout)
         {
-            Expectation expectation;
-            if (this.expectations.TryGetValue(correlationId, out expectation))
+            if (this.expectations.TryGetValue(correlationId, out var expectation))
             {
                 return expectation.Task;
             }
@@ -364,8 +364,7 @@ namespace Contour.Transport.RabbitMQ.Internal
 
                 this.cancellationTokenSource.Cancel(true);
 
-                Task worker;
-                while (this.workers.TryTake(out worker))
+                while (this.workers.TryTake(out var worker))
                 {
                     try
                     {
@@ -378,8 +377,7 @@ namespace Contour.Transport.RabbitMQ.Internal
                     }
                 }
 
-                RabbitChannel channel;
-                while (this.channels.TryTake(out channel))
+                while (this.channels.TryTake(out var channel))
                 {
                     try
                     {
@@ -433,6 +431,9 @@ namespace Contour.Transport.RabbitMQ.Internal
             try
             {
                 var consumer = this.InitializeConsumer(token, out var channel);
+
+                // если шина так и не стала готова работать, то не смысла начинать слушать сообщения, что бы потом их потерять
+                this.busContext.WhenReady.WaitOne();
 
                 while (!token.IsCancellationRequested)
                 {

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitBus.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitBus.cs
@@ -190,6 +190,7 @@ namespace Contour.Transport.RabbitMQ.Internal
                             this.isRestarting.Reset();
                             if (t.IsFaulted)
                             {
+                                this.logger.Error(m => m("Error on restarting bus: {0}", this.Endpoint.Address), t.Exception.InnerException);
                                 throw t.Exception.InnerException;
                             }
                         });

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitBus.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitBus.cs
@@ -49,6 +49,8 @@ namespace Contour.Transport.RabbitMQ.Internal
         /// </summary>
         public void Panic()
         {
+            
+            // TODO никто не вызывает, может стоит удалить метод
             this.Restart();
         }
 
@@ -189,7 +191,9 @@ namespace Contour.Transport.RabbitMQ.Internal
                         {
                             this.isRestarting.Reset();
                             if (t.IsFaulted)
-                            {
+                            {   
+                                // TODO ошибка тут приводит к тому, что сервис зависает навсегда с неготовой шиной
+                                // если раньше это приводило к потере сообщений, при попытке их обработать, теперь сервис просто ничего делать не будет
                                 this.logger.Error(m => m("Error on restarting bus: {0}", this.Endpoint.Address), t.Exception.InnerException);
                                 throw t.Exception.InnerException;
                             }
@@ -197,6 +201,7 @@ namespace Contour.Transport.RabbitMQ.Internal
 
             if (waitForReadiness)
             {
+                // TODO почему ждем 5 секунд, если не дождались, то можем получить неготовую шину до перезапуска
                 this.restartTask.Wait(5000);
             }
         }

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
@@ -89,6 +89,13 @@ namespace Contour.Transport.RabbitMQ.Internal
                     }
                     catch (Exception ex)
                     {
+                        // 10 попыток это 55 секнуд только задержек, плюс само время на коннект
+                        // если не смогли подключиться за это время, то пора пробросить ошибку
+                        if (retryCount > 10)
+                        {
+                            throw;
+                        }
+                        
                         var secondsToRetry = Math.Min(10, retryCount);
 
                         this.logger.Warn(m => m("Unable to connect to RabbitMQ on connection string: [{1}]. Retrying in {0} seconds...", secondsToRetry, this.ConnectionString), ex);

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
@@ -89,6 +89,12 @@ namespace Contour.Transport.RabbitMQ.Internal
                     }
                     catch (Exception ex)
                     {
+                        if (con != null)
+                        {
+                            con.ConnectionShutdown -= this.OnConnectionShutdown;
+                            con.Abort(TimeSpan.FromMilliseconds(OperationTimeout));
+                        }
+
                         // 10 попыток это 55 секнуд только задержек, плюс само время на коннект
                         // если не смогли подключиться за это время, то пора пробросить ошибку
                         if (retryCount > 10)
@@ -99,13 +105,7 @@ namespace Contour.Transport.RabbitMQ.Internal
                         var secondsToRetry = Math.Min(10, retryCount);
 
                         this.logger.Warn(m => m("Unable to connect to RabbitMQ on connection string: [{1}]. Retrying in {0} seconds...", secondsToRetry, this.ConnectionString), ex);
-
-                        if (con != null)
-                        {
-                            con.ConnectionShutdown -= this.OnConnectionShutdown;
-                            con.Abort(TimeSpan.FromMilliseconds(OperationTimeout));
-                        }
-
+                        
                         Thread.Sleep(TimeSpan.FromSeconds(secondsToRetry));
                         retryCount++;
                     }

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
@@ -95,13 +95,6 @@ namespace Contour.Transport.RabbitMQ.Internal
                             con.Abort(TimeSpan.FromMilliseconds(OperationTimeout));
                         }
 
-                        // 10 попыток это 55 секнуд только задержек, плюс само время на коннект
-                        // если не смогли подключиться за это время, то пора пробросить ошибку
-                        if (retryCount > 10)
-                        {
-                            throw;
-                        }
-                        
                         var secondsToRetry = Math.Min(10, retryCount);
 
                         this.logger.Warn(m => m("Unable to connect to RabbitMQ on connection string: [{1}]. Retrying in {0} seconds...", secondsToRetry, this.ConnectionString), ex);


### PR DESCRIPTION
Исправлена ошибка, когда стартует сервис с непустой очередью и теряются сообщения, так как шина еще до конца не инициализирована.
Правка в том, что начинаем обрабатывать сообщения после полной инициализации шины.
Возможны проблемы, когда в сервисе несколько эндпоинтов, так как они ничего не знают друг о друге. Пока не решаем.