### PR TITLE
Busnotready fix2

### DIFF
--- a/Sources/Contour/AbstractBus.cs
+++ b/Sources/Contour/AbstractBus.cs
@@ -533,6 +533,12 @@
         /// <param name="waitForReadiness">Если <c>true</c> - тогда необходимо дождаться готовности шины сообщений.</param>
         public abstract void Start(bool waitForReadiness = true);
 
+
+        /// <summary>
+        /// Предварительное конфигурирование клиента шины без его запуска.
+        /// </summary>
+        public abstract void Prepare();
+
         /// <summary>
         /// Останавливает шину сообщений.
         /// </summary>
@@ -677,12 +683,6 @@
 
             this.Stopping(this, null);
         }
-
-        /// <summary>
-        /// Останавливает и заново запускает шину сообщений.
-        /// </summary>
-        /// <param name="waitForReadiness"><c>true</c> - если нужно дождаться готовности шины.</param>
-        protected abstract void Restart(bool waitForReadiness = true);
 
         /// <summary>
         /// Проверяет возможность отправить сообщение с указанной меткой.

--- a/Sources/Contour/AbstractBus.cs
+++ b/Sources/Contour/AbstractBus.cs
@@ -530,14 +530,13 @@
         /// <summary>
         /// Запускает шину сообщений.
         /// </summary>
-        /// <param name="waitForReadiness">Если <c>true</c> - тогда необходимо дождаться готовности шины сообщений.</param>
-        public abstract void Start(bool waitForReadiness = true);
+        public abstract Task Start();
 
 
         /// <summary>
         /// Предварительное конфигурирование клиента шины без его запуска.
         /// </summary>
-        public abstract void Prepare();
+        public abstract Task Prepare();
 
         /// <summary>
         /// Останавливает шину сообщений.

--- a/Sources/Contour/Configuration/BusConfiguration.cs
+++ b/Sources/Contour/Configuration/BusConfiguration.cs
@@ -20,7 +20,7 @@ namespace Contour.Configuration
         /// <summary>
         /// The logger.
         /// </summary>
-        private static readonly ILog Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILog Logger = LogManager.GetLogger<BusConfiguration>();
 
         /// <summary>
         /// The _filters.

--- a/Sources/Contour/Contour.csproj
+++ b/Sources/Contour/Contour.csproj
@@ -8,7 +8,7 @@
     <Description>The package contains abstract interfaces of service bus and specific transport implementation for AMQP/RabbitMQ</Description>
     <Company>Social Discovery Ventures</Company>
     <Authors>SDV Team</Authors>
-    <Version>2.2.1-core2</Version>
+    <Version>3.0.0-pr-1</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   

--- a/Sources/Contour/IBus.cs
+++ b/Sources/Contour/IBus.cs
@@ -170,6 +170,11 @@ namespace Contour
         /// Необходимо ожидать полной готовности шины.
         /// </param>
         void Start(bool waitForReadiness = true);
+        
+        /// <summary>
+        /// Предварительное конфигурирование клиента шины без его запуска.
+        /// </summary>
+        void Prepare();
 
         /// <summary>
         ///   Остановка клиента шины.

--- a/Sources/Contour/IBus.cs
+++ b/Sources/Contour/IBus.cs
@@ -166,15 +166,14 @@ namespace Contour
         /// <summary>
         /// Конфигурирование и запуск клиента шины.
         /// </summary>
-        /// <param name="waitForReadiness">
-        /// Необходимо ожидать полной готовности шины.
-        /// </param>
-        void Start(bool waitForReadiness = true);
-        
+        /// <returns>Задача cтартующая шину.</returns>
+        Task Start();
+
         /// <summary>
         /// Предварительное конфигурирование клиента шины без его запуска.
         /// </summary>
-        void Prepare();
+        /// <returns>Задача конфигурирующая шину.</returns>
+        Task Prepare();
 
         /// <summary>
         ///   Остановка клиента шины.

--- a/Sources/Contour/IBusAdvanced.cs
+++ b/Sources/Contour/IBusAdvanced.cs
@@ -29,14 +29,5 @@
         IEnumerable<ISender> Senders { get; }
 
         #endregion
-
-        #region Public Methods and Operators
-
-        /// <summary>
-        ///   Принудительный перезапуск клиента шины.
-        /// </summary>
-        void Panic();
-
-        #endregion
     }
 }

--- a/Sources/Contour/IChannelProvider.cs
+++ b/Sources/Contour/IChannelProvider.cs
@@ -13,13 +13,6 @@ namespace Contour
         /// <summary>
         /// Opens a new channel in the underlying connection
         /// </summary>
-        /// <returns>An open channel</returns>
-        [Obsolete("Use cancellable version")]
-        TChannel OpenChannel();
-
-        /// <summary>
-        /// Opens a new channel in the underlying connection
-        /// </summary>
         /// <param name="token">
         /// Operation cancellation token
         /// </param>

--- a/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/Listener.cs
@@ -436,6 +436,11 @@ namespace Contour.Transport.RabbitMQ.Internal
                 // если шина так и не стала готова работать, то не смысла начинать слушать сообщения, что бы потом их потерять
                 while (true)
                 {
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+                    
                     if (!this.busContext.WhenReady.WaitOne(60000))
                     {
                         waitSecond += 60;
@@ -457,7 +462,7 @@ namespace Contour.Transport.RabbitMQ.Internal
             }
             catch (OperationCanceledException)
             {
-                this.logger.Info($"Consume operation of listener has been canceled");
+                this.logger.Info("Consume operation of listener has been canceled");
             }
             catch (Exception ex)
             {

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitBus.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitBus.cs
@@ -91,7 +91,7 @@ namespace Contour.Transport.RabbitMQ.Internal
 
         public override void Stop()
         {
-            this.ResetRestartTask();
+            this.ResetStartTask();
 
             var token = this.cancellationTokenSource.Token;
             this.startTask = Task.Factory.StartNew(this.StopTask, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
@@ -241,7 +241,7 @@ namespace Contour.Transport.RabbitMQ.Internal
             this.OnStopped();
         }
 
-        private void ResetRestartTask()
+        private void ResetStartTask()
         {
             if (!this.startTask.IsCompleted)
             {

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitChannel.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitChannel.cs
@@ -316,7 +316,15 @@
         /// </param>
         public void SetQos(QoSParams qos)
         {
-            this.SafeNativeInvoke(n => n.BasicQos(qos.PrefetchSize, qos.PrefetchCount, false));
+            try
+            {
+                this.SafeNativeInvoke(n => n.BasicQos(qos.PrefetchSize, qos.PrefetchCount, false));
+            }
+            catch (Exception e)
+            {
+                this.logger.Error(m => m("Failed to set Qos on channel: {0}", this.ToString()), e);
+                throw;
+            }
         }
 
         /// <summary>
@@ -336,11 +344,19 @@
         /// </returns>
         public string StartConsuming(IListeningSource listeningSource, bool requireAccept, IBasicConsumer consumer)
         {
-            string consumerTag = string.Empty;
+            try
+            {
+                var consumerTag = string.Empty;
 
-            this.SafeNativeInvoke(n => consumerTag = n.BasicConsume(listeningSource.Address, !requireAccept, consumer));
+                this.SafeNativeInvoke(n => consumerTag = n.BasicConsume(listeningSource.Address, !requireAccept, consumer));
 
-            return consumerTag;
+                return consumerTag;
+            }
+            catch (Exception e)
+            {
+                this.logger.Error(m => m("Failed start consuming on channel."), e);
+                throw;
+            }
         }
 
         /// <summary>

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitChannel.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitChannel.cs
@@ -229,7 +229,7 @@
         /// </returns>
         public ulong GetNextSeqNo()
         {
-            var seqNo = 0UL;
+            ulong seqNo = 0UL;
             this.SafeNativeInvoke(n => seqNo = n.NextPublishSeqNo);
             return seqNo;
         }

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitChannel.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitChannel.cs
@@ -298,17 +298,6 @@
         }
 
         /// <summary>
-        /// The request publish.
-        /// </summary>
-        /// <param name="qos">
-        /// The qos.
-        /// </param>
-        public void RequestPublish(QoSParams qos)
-        {
-            this.SafeNativeInvoke(n => n.BasicQos(qos.PrefetchSize, qos.PrefetchCount, false));
-        }
-
-        /// <summary>
         /// The set qos.
         /// </summary>
         /// <param name="qos">
@@ -356,39 +345,6 @@
             {
                 this.logger.Error(m => m("Failed start consuming on channel."), e);
                 throw;
-            }
-        }
-
-        /// <summary>
-        /// The stop consuming.
-        /// </summary>
-        /// <param name="consumerTag">
-        /// The consumer tag.
-        /// </param>
-        public void StopConsuming(string consumerTag)
-        {
-            this.SafeNativeInvoke(n => n.BasicCancel(consumerTag));
-        }
-
-        /// <summary>
-        /// The try stop consuming.
-        /// </summary>
-        /// <param name="consumerTag">
-        /// The consumer tag.
-        /// </param>
-        /// <returns>
-        /// The <see cref="bool"/>.
-        /// </returns>
-        public bool TryStopConsuming(string consumerTag)
-        {
-            try
-            {
-                this.Model.BasicCancel(consumerTag);
-                return true;
-            }
-            catch
-            {
-                return false;
             }
         }
 

--- a/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
+++ b/Sources/Contour/Transport/RabbitMQ/Internal/RabbitConnection.cs
@@ -106,30 +106,6 @@ namespace Contour.Transport.RabbitMQ.Internal
             }
         }
 
-        [Obsolete("Use cancellable version")]
-        public RabbitChannel OpenChannel()
-        {
-            lock (this.syncRoot)
-            {
-                if (this.connection == null || !this.connection.IsOpen)
-                {
-                    throw new InvalidOperationException("RabbitMQ connection is not open.");
-                }
-
-                try
-                {
-                    var model = this.connection.CreateModel();
-                    var channel = new RabbitChannel(this.Id, model, this.busContext, this.ConnectionString);
-                    return channel;
-                }
-                catch (Exception ex)
-                {
-                    this.logger.Error($"Failed to open a new channel in connection [{this}] due to: {ex.Message}", ex);
-                    throw;
-                }
-            }
-        }
-
         public RabbitChannel OpenChannel(CancellationToken token)
         {
             lock (this.syncRoot)


### PR DESCRIPTION
Даем возможность клиентам шины разделить конфигурирование и подключение к шине и старт оброботки сообщений, для возможности синхронизировать старт между несколькими шинами.
Так же добавлено дополнительное логгирование и нарушена обратная совместимость.